### PR TITLE
add build step to ci-typescript workflow

### DIFF
--- a/.github/workflows/ci-typescript.yaml
+++ b/.github/workflows/ci-typescript.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: Lint and Build
 on:
   pull_request:
     paths:
@@ -25,3 +25,5 @@ jobs:
         run: yarn install --frozen-lockfile
       - name: Lint
         run: yarn lint
+      - name: Build
+        run: yarn build


### PR DESCRIPTION
# Why
add build step to ci-typescript workflow