### PR TITLE
Feature/compose supergraph schema with rover

### DIFF
--- a/typescript/apps/apollo-supergraph-gateway/README.md
+++ b/typescript/apps/apollo-supergraph-gateway/README.md
@@ -1,0 +1,14 @@
+# apollo-supergraph-gateway
+- An apollo federated supergraph implementation with `@apollo/gateway` package.
+- https://www.apollographql.com/docs/apollo-server/using-federation/api/apollo-gateway
+
+# Generate supergraph schema
+## Install Rover
+see: https://www.apollographql.com/docs/rover/getting-started/
+
+## Run command
+see: https://www.apollographql.com/docs/rover/commands/supergraphs#composing-a-supergraph-schema
+
+```bash
+$ rover supergraph compose --config ./supergraph.yaml > ./supergraph.graphqls
+```

--- a/typescript/apps/apollo-supergraph-gateway/src/main.ts
+++ b/typescript/apps/apollo-supergraph-gateway/src/main.ts
@@ -1,18 +1,54 @@
 import { ApolloServer } from '@apollo/server';
 import { startStandaloneServer } from '@apollo/server/standalone';
-import { ApolloGateway, IntrospectAndCompose } from '@apollo/gateway';
+import { ApolloGateway } from '@apollo/gateway';
+import { watch } from 'fs';
+import { readFile } from 'fs/promises';
 
 const gateway = new ApolloGateway({
   // !! Avoid using `IntrospectAndCompose` in production, since it has some critical limitations.
   // For details, see: https://www.apollographql.com/docs/apollo-server/using-federation/apollo-gateway-setup/#limitations-of-introspectandcompose
-  supergraphSdl: new IntrospectAndCompose({
-    subgraphs: [
-      { name: 'reviews', url: 'http://localhost:4001/graphql' },
-      { name: 'zoos', url: 'http://localhost:4002/graphql' },
-      { name: 'animals', url: 'http://localhost:4003/graphql' }
-    ],
-    subgraphHealthCheck: true,
-  }),
+  // supergraphSdl: new IntrospectAndCompose({
+  //   subgraphs: [
+  //     { name: 'reviews', url: 'http://localhost:4001/graphql' },
+  //     { name: 'zoos', url: 'http://localhost:4002/graphql' },
+  //     { name: 'animals', url: 'http://localhost:4003/graphql' }
+  //   ],
+  //   subgraphHealthCheck: true,
+  // }),
+
+  // https://www.apollographql.com/docs/apollo-server/using-federation/apollo-gateway-setup#updating-the-supergraph-schema
+  async supergraphSdl({ update, healthCheck }) {
+    // create a file watcher
+    const watcher = watch('apps/apollo-supergraph-gateway/supergraph.graphqls');
+    // subscribe to file changes
+    watcher.on('change', async () => {
+      // update the supergraph schema
+      try {
+        const updatedSupergraph = await readFile(
+          'apps/apollo-supergraph-gateway/supergraph.graphqls',
+          'utf-8'
+        );
+        // optional health check update to ensure our services are responsive
+        await healthCheck(updatedSupergraph);
+        // update the supergraph schema
+        update(updatedSupergraph);
+      } catch (e) {
+        // handle errors that occur during health check or while updating the supergraph schema
+        console.error(e);
+      }
+    });
+
+    return {
+      supergraphSdl: await readFile(
+        'apps/apollo-supergraph-gateway/supergraph.graphqls',
+        'utf-8'
+      ),
+      // cleanup is called when the gateway is stopped
+      async cleanup() {
+        watcher.close();
+      },
+    };
+  },
 });
 
 async function startApolloServer() {

--- a/typescript/apps/apollo-supergraph-gateway/supergraph.graphqls
+++ b/typescript/apps/apollo-supergraph-gateway/supergraph.graphqls
@@ -1,0 +1,124 @@
+schema
+  @link(url: "https://specs.apollo.dev/link/v1.0")
+  @link(url: "https://specs.apollo.dev/join/v0.2", for: EXECUTION) {
+  query: Query
+  mutation: Mutation
+}
+
+directive @join__field(
+  graph: join__Graph!
+  requires: join__FieldSet
+  provides: join__FieldSet
+  type: String
+  external: Boolean
+  override: String
+  usedOverridden: Boolean
+) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+directive @join__implements(
+  graph: join__Graph!
+  interface: String!
+) repeatable on OBJECT | INTERFACE
+
+directive @join__type(
+  graph: join__Graph!
+  key: join__FieldSet
+  extension: Boolean! = false
+  resolvable: Boolean! = true
+) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+directive @link(
+  url: String
+  as: String
+  for: link__Purpose
+  import: [link__Import]
+) repeatable on SCHEMA
+
+type Animal
+  @join__type(graph: ANIMALS, key: "id")
+  @join__type(graph: ZOOS, key: "id") {
+  id: ID!
+  name: String!
+  classis: Classis! @join__field(graph: ANIMALS)
+}
+
+input AnimalInput @join__type(graph: ZOOS) {
+  id: String!
+  name: String!
+}
+
+enum Area @join__type(graph: ZOOS) {
+  TOHOKU
+  KANTO
+  KOSHINETSU
+  HOKURIKU
+  TOKAI
+  KINKI
+  CHUGOKU
+  SHIKOKU
+  KYUSYU
+}
+
+type Classis @join__type(graph: ANIMALS) {
+  name: String!
+}
+
+scalar join__FieldSet
+
+enum join__Graph {
+  ANIMALS @join__graph(name: "animals", url: "http://localhost:4003/graphql")
+  REVIEWS @join__graph(name: "reviews", url: "http://localhost:4001/graphql")
+  ZOOS @join__graph(name: "zoos", url: "http://localhost:4002/graphql")
+}
+
+scalar link__Import
+
+enum link__Purpose {
+  """
+  `SECURITY` features provide metadata necessary to securely resolve fields.
+  """
+  SECURITY
+
+  """
+  `EXECUTION` features provide metadata necessary for operation execution.
+  """
+  EXECUTION
+}
+
+type Mutation @join__type(graph: ZOOS) {
+  registerZoo(zoo: ZooInput!): [Zoo!]!
+}
+
+type Query
+  @join__type(graph: ANIMALS)
+  @join__type(graph: REVIEWS)
+  @join__type(graph: ZOOS) {
+  animals: [Animal!]! @join__field(graph: ANIMALS)
+  reviews: [Review!]! @join__field(graph: REVIEWS)
+  zoos: [Zoo!]! @join__field(graph: ZOOS)
+}
+
+type Review @join__type(graph: REVIEWS, key: "id") {
+  id: ID!
+  score: Int!
+  zooId: Int!
+  zoo: Zoo!
+}
+
+type Zoo
+  @join__type(graph: REVIEWS, key: "id")
+  @join__type(graph: ZOOS, key: "id") {
+  id: ID!
+  reviews: [Review]! @join__field(graph: REVIEWS)
+  name: String! @join__field(graph: ZOOS)
+  area: Area! @join__field(graph: ZOOS)
+  animals: [Animal!]! @join__field(graph: ZOOS)
+}
+
+input ZooInput @join__type(graph: ZOOS) {
+  name: String!
+  area: Area!
+  animals: [AnimalInput!]! = []
+}

--- a/typescript/apps/apollo-supergraph-gateway/supergraph.yaml
+++ b/typescript/apps/apollo-supergraph-gateway/supergraph.yaml
@@ -1,0 +1,14 @@
+federation_version: 2
+subgraphs:
+  reviews:
+    routing_url: http://localhost:4001/graphql
+    schema:
+      subgraph_url: http://localhost:4001/graphql
+  zoos:
+    routing_url: http://localhost:4002/graphql
+    schema:
+      subgraph_url: http://localhost:4002/graphql
+  animals:
+    routing_url: http://localhost:4003/graphql
+    schema:
+      subgraph_url: http://localhost:4003/graphql


### PR DESCRIPTION
# Why
To avoid using `IntrospectAndCompose` in apollo-supergraph-gateway` implementation, introducing [Rover CLI](https://www.apollographql.com/docs/rover/) to compose supergraph schema.

# What
- re-implement apollo-supergraph-gateway with method explained in https://www.apollographql.com/docs/apollo-server/using-federation/apollo-gateway-setup#updating-the-supergraph-schema
- add README file to run Rover CLI